### PR TITLE
Allow changing case to one field only

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,9 +30,9 @@ lazy val derivation = project
 lazy val circeDerivation = project
     .in(modules / "circeDerivation")
     .settings(
-      name := "derivation-circe",
-      libraryDependencies += "io.circe" %% "circe-core" % Version.circe,
+      name                              := "derivation-circe",
+      libraryDependencies += "io.circe" %% "circe-core"   % Version.circe,
       libraryDependencies += "io.circe" %% "circe-parser" % Version.circe % Test,
-      defaultSettings
+      defaultSettings,
     )
     .dependsOn(derivation)

--- a/modules/circeDerivation/src/main/scala/evo/derivation/circe/EvoDecoder.scala
+++ b/modules/circeDerivation/src/main/scala/evo/derivation/circe/EvoDecoder.scala
@@ -115,4 +115,3 @@ object EvoDecoder:
 
     class NewtypeDecoder[A](using nt: ValueClass[A])(using enc: Decoder[nt.Representation]) extends EvoDecoder[A]:
         override def apply(c: HCursor): Result[A] = c.as[nt.Representation].map(nt.from)
-

--- a/modules/circeDerivation/src/main/scala/evo/derivation/circe/EvoDecoder.scala
+++ b/modules/circeDerivation/src/main/scala/evo/derivation/circe/EvoDecoder.scala
@@ -29,7 +29,7 @@ object EvoDecoder:
         summonFrom {
             case given Mirror.ProductOf[A] => deriveForProduct[A].instance
             case given Mirror.SumOf[A]     => deriveForSum[A]
-            case given ValueClass[A]       => deriveForNewtype[A]
+            case given ValueClass[A]       => deriveForValueClass[A]
             case _                         => underiveableError[EvoDecoder[A], A]
         }
 
@@ -49,7 +49,7 @@ object EvoDecoder:
 
         SumDecoder(config, mirror)(constInstances.toMap[A](names), names)
 
-    private inline def deriveForNewtype[A](using nt: ValueClass[A]): EvoDecoder[A] =
+    private inline def deriveForValueClass[A](using nt: ValueClass[A]): EvoDecoder[A] =
         given Decoder[nt.Representation] = summonInline
 
         NewtypeDecoder[A]()

--- a/modules/circeDerivation/src/test/scala/evo/derivation/circe/EvoDecoderChecks.scala
+++ b/modules/circeDerivation/src/test/scala/evo/derivation/circe/EvoDecoderChecks.scala
@@ -97,9 +97,9 @@ class EvoEncoderChecks extends FunSuite:
 object CheckData:
     class TestClass derives Config
 
-    val Package       = "evo.derivation.circe"
-    val DecoderTypeName  = s"$Package.EvoDecoder"
-    val TestClassName      = s"$Package.CheckData.TestClass"
+    val Package                = "evo.derivation.circe"
+    val DecoderTypeName        = s"$Package.EvoDecoder"
+    val TestClassName          = s"$Package.CheckData.TestClass"
     val AppliedDecoderTypeName = s"$DecoderTypeName[$TestClassName]"
 
     case class Person(name: String, age: Int) derives Config, EvoDecoder, EvoEncoder
@@ -152,10 +152,7 @@ object CheckData:
 
     val writeJson = s"""{"mode" : "w", "append":true, "bin": true}"""
 
-    case class Dictionary(key: String, value: String, next: Option[Dictionary])
-        derives Config,
-          EvoDecoder,
-          EvoEncoder
+    case class Dictionary(key: String, value: String, next: Option[Dictionary]) derives Config, EvoDecoder, EvoEncoder
 
     val dictionaryJson = """{"key" : "a", "value" : "arbuz", "next" : {"key": "b", "value" : "baraban"}}"""
 

--- a/modules/derivation/src/main/scala/evo/derivation/Config.scala
+++ b/modules/derivation/src/main/scala/evo/derivation/Config.scala
@@ -27,10 +27,10 @@ case class Config[+T](
             case ct: CaseTransformation    =>
                 val transformation = Config.caseConfiguration(ct)
                 fieldName match
-                //for field: transform only this field
-                case Some(field) => copy(top =  top.applyRenaming(Some(field), transformation(field)))
-                //for class/enum: transform everything
-                case None => withRenaming(transformation)
+                    //for field: transform only this field
+                    case Some(field) => copy(top =  top.applyRenaming(Some(field), transformation(field)))
+                    //for class/enum: transform everything
+                    case None => withRenaming(transformation)
             case Discriminator(dis) => copy(discriminator = Some(dis))
             case Rename(newName)    => copy(top = top.applyRenaming(fieldName, newName))
             case Embed()            =>

--- a/modules/derivation/src/main/scala/evo/derivation/Config.scala
+++ b/modules/derivation/src/main/scala/evo/derivation/Config.scala
@@ -1,5 +1,5 @@
 package evo.derivation
-import scala.compiletime.{summonFrom, constValueTuple}
+import scala.compiletime.{summonFrom, constValueTuple, constValue}
 
 import Config.Renaming
 import scala.deriving.Mirror
@@ -8,6 +8,7 @@ import scala.quoted.Type
 import scala.quoted.Expr
 import scala.quoted.Varargs
 import evo.derivation.Config.ForProduct
+import scala.compiletime.{codeOf, error}
 
 case class Config[+T](
     top: Config.ForProduct = Config.ForProduct(),
@@ -23,7 +24,13 @@ case class Config[+T](
 
     def applyAnnotation(annotation: DerivationAnnotation, fieldName: Option[String] = None): Config[T] =
         annotation match
-            case SnakeCase()        => withRenaming(Config.snakeCase)
+            case ct: CaseTransformation    =>
+                val transformation = Config.caseConfiguration(ct)
+                fieldName match
+                //for field: transform only this field
+                case Some(field) => copy(top =  top.applyRenaming(Some(field), transformation(field)))
+                //for class/enum: transform everything
+                case None => withRenaming(transformation)
             case Discriminator(dis) => copy(discriminator = Some(dis))
             case Rename(newName)    => copy(top = top.applyRenaming(fieldName, newName))
             case Embed()            =>
@@ -49,22 +56,30 @@ object Config:
 
     val default: Config[Nothing] = Config()
 
-    val snakeCase: Renaming = _.split("(?<=\\p{Lower})(?=\\p{Upper})").nn.mkString("_").nn.toLowerCase.nn
+    private val extractWords = (input: String) => input.split("(?<=\\p{Lower})(?=\\p{Upper})")
+
+    val snakeCase: Renaming = extractWords(_).nn.mkString("_").nn.toLowerCase.nn
+
+    val kebabCase: Renaming = extractWords(_).nn.mkString("-").nn.toLowerCase.nn
+
+    inline def caseConfiguration(ct: CaseTransformation): Renaming = ct match
+        case SnakeCase() => snakeCase
+        case KebabCase() => kebabCase
 
     case class ForProduct(
-        fields: Vector[String] = Vector(),
-        renamed: Option[String] = None,
-        fieldNames: Map[String, String] = Map.empty,
-        embedFields: Set[String] = Set.empty,
-        fieldRenaming: Renaming = identity,
+                             fields: Vector[String] = Vector(),
+                             renamed: Option[String] = None,
+                             transformedFields: Map[String, String] = Map.empty,
+                             embedFields: Set[String] = Set.empty,
+                             fieldRenaming: Renaming = identity,
     ):
-        def applyRenaming(field: Option[String], newName: String) = field match
-            case Some(oldName) => copy(fieldNames = fieldNames + (oldName -> newName))
+        def applyRenaming(field: Option[String], newName: String): ForProduct = field match
+            case Some(oldName) => copy(transformedFields = transformedFields + (oldName -> newName) )
             case None          => copy(renamed = Some(newName))
 
-        def embedField(field: String) = copy(embedFields = embedFields + field)
+        def embedField(field: String): ForProduct = copy(embedFields = embedFields + field)
 
-        def name(field: String) = fieldNames.getOrElse(field, fieldRenaming(field))
+        def name(field: String): String = transformedFields.getOrElse(field, fieldRenaming(field))
 
         def fieldInfo(field: String): FieldInfo = FieldInfo(name = name(field), embed = embedFields(field))
 

--- a/modules/derivation/src/main/scala/evo/derivation/annotations.scala
+++ b/modules/derivation/src/main/scala/evo/derivation/annotations.scala
@@ -3,20 +3,34 @@ package evo.derivation
 import scala.annotation.StaticAnnotation
 
 sealed trait DerivationAnnotation extends StaticAnnotation
+
+/** Case transformation
+  *
+  *   - if used on enum/value class/case class, it will change all field and constructor names;
+  *   - if used directly on field it will change this field only.
+  *
+  * @note
+  *   It's expected that original names are in camelCaseForm.
+  */
 sealed trait CaseTransformation extends DerivationAnnotation
 
-/**  Transforms data to to snake_case_form
- *
- *   - If used on enum/value class/case class, it will change all field and constructor names
- *   - If used directly on field it will change this field only
- */
+/** Transforms names to to snake_case_form
+  *
+  * @inheritdoc
+  */
 case class SnakeCase() extends CaseTransformation
 
-/**  Transforms data to to kebab-case-form
- *
- *   - If used on enum/value class/case class, it will change all field and constructor names
- *   - If used directly on field it will change this field only
- */case class KebabCase() extends CaseTransformation
+/** Transforms names to to kebab-case-form
+  *
+  * @inheritdoc
+  */
+case class KebabCase() extends CaseTransformation
+
+/** Transforms names to to PascalCaseForm
+  *
+  * @inheritdoc
+  */
+case class PascalCase() extends CaseTransformation
 
 /** This enum will use discriminator field with given name */
 case class Discriminator(name: String) extends DerivationAnnotation

--- a/modules/derivation/src/main/scala/evo/derivation/annotations.scala
+++ b/modules/derivation/src/main/scala/evo/derivation/annotations.scala
@@ -3,11 +3,22 @@ package evo.derivation
 import scala.annotation.StaticAnnotation
 
 sealed trait DerivationAnnotation extends StaticAnnotation
+sealed trait CaseTransformation extends DerivationAnnotation
 
-/** all fields and constructor names of this case class enum will be renamed to snake case form */
-case class SnakeCase() extends DerivationAnnotation
+/**  Transforms data to to snake_case_form
+ *
+ *   - If used on enum/value class/case class, it will change all field and constructor names
+ *   - If used directly on field it will change this field only
+ */
+case class SnakeCase() extends CaseTransformation
 
-/** this enum will use discriminator field with given name */
+/**  Transforms data to to kebab-case-form
+ *
+ *   - If used on enum/value class/case class, it will change all field and constructor names
+ *   - If used directly on field it will change this field only
+ */case class KebabCase() extends CaseTransformation
+
+/** This enum will use discriminator field with given name */
 case class Discriminator(name: String) extends DerivationAnnotation
 
 /** this field or this constructor will be renamed to `name` */

--- a/modules/derivation/src/main/scala/evo/derivation/internal/product.scala
+++ b/modules/derivation/src/main/scala/evo/derivation/internal/product.scala
@@ -13,5 +13,5 @@ private def subtypeToIntersectionEq[A, B](using ev: A <:< B): A =:= (A & B) =
     given (A <:< (A & B)) = ev.liftCo[[x] =>> A & x]
     <:<.antisymm
 
-inline def mirroredNames[A](using mirror : Mirror.Of[A]): Vector[String] = 
+inline def mirroredNames[A](using mirror: Mirror.Of[A]): Vector[String] =
     constValueTuple[mirror.MirroredElemLabels].toIArray.toVector.asInstanceOf[Vector[String]]

--- a/modules/derivation/src/test/scala/evo/derivation/AnnotationsTest.scala
+++ b/modules/derivation/src/test/scala/evo/derivation/AnnotationsTest.scala
@@ -1,22 +1,28 @@
 package evo.derivation
 
-import AnnotationTest.Izbushka
-import evo.derivation.AnnotationTest.Baba
+import AnnotationTest.{Baba, Izbushka, Pech}
 
 class AnnotationsTest extends munit.FunSuite:
     test("isbuzhka") {
         val cfg = summon[Config[Izbushka]]
-        assertEquals(cfg.top.fieldRenaming, Config.snakeCase)
-        assertEquals(cfg.top.fieldNames, Map("ping" -> "pong"))
+        assertEquals(cfg.top.fieldRenaming("FooFoo"), ("foo_foo"))
+        assertEquals(cfg.top.transformedFields, Map("ping" -> "pong"))
         assertEquals(cfg.top.embedFields, Set("azaza"))
     }
 
     test("baba") {
         val cfg = summon[Config[Baba]]
-        assertEquals(cfg.constructorRenaming, Config.snakeCase)
+        assertEquals(cfg.constructorRenaming("FooFoo"), "foo_foo")
         assertEquals(cfg.constructors("Yaga").renamed, Some("Jaga"))
         assertEquals(cfg.constructors("Noga").fieldRenaming("AbCd"), "ab_cd")
         assertEquals(cfg.constructors("Kostyanaya").fieldRenaming("AbCd"), "ab_cd")
+    }
+
+    test("pech"){
+        val cfg = summon[Config[Pech]]
+        assertEquals(cfg.constructorRenaming("Pech"), "Pech")
+        assertEquals(cfg.top.transformedFields, Map("Ivan" -> "ivan"))
+        assertEquals(cfg.top.fieldRenaming("Fool"), "Fool")
     }
 
 object AnnotationTest:
@@ -31,3 +37,8 @@ object AnnotationTest:
         @Rename("Jaga") case Yaga
         case Kostyanaya(lolJe: String = "", kekJi: Double = 0)
         case Noga(@Embed cheburek: Izbushka)
+
+    case class Pech(
+        @SnakeCase Ivan: String,
+        quality: String
+                   ) derives Config

--- a/modules/derivation/src/test/scala/evo/derivation/AnnotationsTest.scala
+++ b/modules/derivation/src/test/scala/evo/derivation/AnnotationsTest.scala
@@ -1,6 +1,6 @@
 package evo.derivation
 
-import AnnotationTest.{Baba, Izbushka, Pech}
+import AnnotationTest.{Baba, Izbushka, Pech, Gosudarstvo}
 
 class AnnotationsTest extends munit.FunSuite:
     test("isbuzhka") {
@@ -18,12 +18,25 @@ class AnnotationsTest extends munit.FunSuite:
         assertEquals(cfg.constructors("Kostyanaya").fieldRenaming("AbCd"), "ab_cd")
     }
 
-    test("pech"){
+    test("pech") {
         val cfg = summon[Config[Pech]]
         assertEquals(cfg.constructorRenaming("Pech"), "Pech")
         assertEquals(cfg.top.transformedFields, Map("Ivan" -> "ivan"))
-        assertEquals(cfg.top.fieldRenaming("Fool"), "Fool")
+        assertEquals(cfg.top.fieldRenaming("Durak"), "Durak")
     }
+
+    test("gosudarstvo") {
+        val cfg = summon[Config[Gosudarstvo]]
+        assertEquals(
+          cfg.top.transformedFields,
+          Map(
+            "tridesatoyeGosudarstvo"  -> "TridesatoyeGosudarstvo",
+            "tridevyatoyeGosudarstvo" -> "tridevyatoye-gosudarstvo",
+          ),
+        )
+    }
+
+
 
 object AnnotationTest:
     @SnakeCase
@@ -40,5 +53,10 @@ object AnnotationTest:
 
     case class Pech(
         @SnakeCase Ivan: String,
-        quality: String
-                   ) derives Config
+        Durak: true,
+    ) derives Config
+
+    case class Gosudarstvo(
+        @PascalCase() tridesatoyeGosudarstvo: String,
+        @KebabCase() tridevyatoyeGosudarstvo: String,
+    ) derives Config

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,7 +1,7 @@
 object Version {
-  val scala = "3.1.3"
+    val scala = "3.1.3"
 
-  val circe = "0.15.0-M1"
+    val circe = "0.15.0-M1"
 
-  val munit = "0.7.29"
+    val munit = "0.7.29"
 }


### PR DESCRIPTION
If someone would want to make only one field of product to be snake case, then they would need to copy paste it as in `@Rename("snake_cased_field_name)" SnakeCasedFieldName`. This PR makes that task easier by allowing to write `@SnakeCase` annotation directly near the field.

Also this PR adds kebab-case and PascalCase just to be kinda complete.

Also, as I didn't know the project was unformatted, this MR formats a bunch of files. If required, I can do it in a separate PR.