### PR TITLE
fix: remove infinite loop caused by summonInline value being assigned to given

### DIFF
--- a/modules/cats/src/main/scala/evo/derivation/cats/EvoEq.scala
+++ b/modules/cats/src/main/scala/evo/derivation/cats/EvoEq.scala
@@ -62,9 +62,9 @@ object EvoEq:
     end deriveForSum
 
     private inline def deriveForValueClass[A](using nt: ValueClass[A]): EvoEq[A] =
-        given Requirement[nt.Representation] = summonInline
+        val requirement: Requirement[nt.Representation] = summonInline
 
-        ValueClasEq[A]()
+        ValueClasEq[A](using nt)(using requirement)
 
     class ProductEq[A](mirror: Mirror.ProductOf[A])(using A <:< Product)(
         instances: LazySummon.All[Requirement, mirror.MirroredElemTypes],

--- a/modules/circe/src/main/scala/evo/derivation/circe/EvoDecoder.scala
+++ b/modules/circe/src/main/scala/evo/derivation/circe/EvoDecoder.scala
@@ -53,9 +53,9 @@ object EvoDecoder:
     end deriveForSum
 
     private inline def deriveForValueClass[A](using nt: ValueClass[A]): EvoDecoder[A] =
-        given Decoder[nt.Representation] = summonInline
+        val decoder: Decoder[nt.Representation] = summonInline
 
-        NewtypeDecoder[A]()
+        NewtypeDecoder[A](using nt)(using decoder)
 
     extension [A](oa: Option[A])
         private def toFailure(s: => String): Decoder.Result[A] = oa.toRight(DecodingFailure(s, Nil))

--- a/modules/circe/src/main/scala/evo/derivation/circe/EvoEncoder.scala
+++ b/modules/circe/src/main/scala/evo/derivation/circe/EvoEncoder.scala
@@ -57,9 +57,9 @@ object EvoEncoder:
     end deriveForProduct
 
     private inline def deriveForNewtype[A](using nt: ValueClass[A]): EvoEncoder[A] =
-        given Encoder[nt.Representation] = summonInline
+        val encoder: Encoder[nt.Representation] = summonInline
 
-        NewtypeEncoder[A]()
+        NewtypeEncoder[A](using nt)(using encoder)
 
     class ProductEncoder[A](using mirror: Mirror.ProductOf[A])(using A <:< Product)(
         fieldInstances: LazySummon.All[Encoder, mirror.MirroredElemTypes],

--- a/modules/playJson/src/main/scala/evo/derivation/play/json/EvoReads.scala
+++ b/modules/playJson/src/main/scala/evo/derivation/play/json/EvoReads.scala
@@ -57,8 +57,8 @@ object EvoReads:
     end deriveForSum
 
     private inline def deriveForValueClass[A](using nt: ValueClass[A]): EvoReads[A] =
-        given Reads[nt.Representation] = summonInline
-        NewtypeReads[A]()
+        val reads: Reads[nt.Representation] = summonInline
+        NewtypeReads[A](using nt)(using reads)
 
     inline given [A: Mirror.ProductOf]: LazySummonByConfig[EvoReads, A] = deriveForProduct[A]
 

--- a/modules/playJson/src/main/scala/evo/derivation/play/json/EvoWrites.scala
+++ b/modules/playJson/src/main/scala/evo/derivation/play/json/EvoWrites.scala
@@ -54,9 +54,9 @@ object EvoWrites:
     end deriveForProduct
 
     private inline def deriveForNewtype[A](using nt: ValueClass[A]): EvoWrites[A] =
-        given Writes[nt.Representation] = summonInline
+        val writes: Writes[nt.Representation] = summonInline
 
-        NewtypeWrites[A]()
+        NewtypeWrites[A](using nt)(using writes)
 
     class ProductWritesMake[A](using mirror: Mirror.ProductOf[A])(using A <:< Product)(
         fieldInstances: LazySummon.All[Writes, mirror.MirroredElemTypes],

--- a/modules/tests/src/main/scala/evo/derivation/tests/data/User.scala
+++ b/modules/tests/src/main/scala/evo/derivation/tests/data/User.scala
@@ -6,7 +6,6 @@ import evo.derivation.circe.{EvoDecoder, EvoEncoder}
 import evo.derivation.config.Config
 import evo.derivation.play.json.{EvoReads, EvoWrites}
 
-
 final case class Login(value: String) extends AnyVal derives Config, EvoDecoder, EvoEncoder, EvoReads, EvoWrites, EvoEq
 
 enum User derives Config, EvoDecoder, EvoEncoder, EvoReads, EvoWrites, EvoEq:

--- a/modules/tests/src/main/scala/evo/derivation/tests/data/User.scala
+++ b/modules/tests/src/main/scala/evo/derivation/tests/data/User.scala
@@ -6,16 +6,19 @@ import evo.derivation.circe.{EvoDecoder, EvoEncoder}
 import evo.derivation.config.Config
 import evo.derivation.play.json.{EvoReads, EvoWrites}
 
+
+final case class Login(value: String) extends AnyVal derives Config, EvoDecoder, EvoEncoder, EvoReads, EvoWrites, EvoEq
+
 enum User derives Config, EvoDecoder, EvoEncoder, EvoReads, EvoWrites, EvoEq:
-    case Authorized(login: String)
+    case Authorized(login: Login)
     case Anonymous
-    case Admin(login: String, @Rename("access") rights: String)
+    case Admin(login: Login, @Rename("access") rights: String)
 
 object User:
 
-    val authorized = User.Authorized("ololo")
+    val authorized = User.Authorized(Login("ololo"))
 
-    val admin = User.Admin("ololo", "kek")
+    val admin = User.Admin(Login("ololo"), "kek")
 
     val authorizedJson = s"""{"Authorized" : {"login": "ololo"}}"""
 

--- a/modules/tests/src/test/scala/evo/derivation/tests/EvoEqChecks.scala
+++ b/modules/tests/src/test/scala/evo/derivation/tests/EvoEqChecks.scala
@@ -20,9 +20,9 @@ class EvoEqChecks extends FunSuite:
 
     test("plain coproduct") {
         assert(User.authorized === User.authorized)
-        assert(User.authorized =!= User.Authorized("kekeke"))
+        assert(User.authorized =!= User.Authorized(Login("kekeke")))
 
-        def admin = User.Admin("jane", "titan")
+        def admin = User.Admin(Login("jane"), "titan")
         assert(User.Anonymous === User.Anonymous)
         assert(User.authorized =!= User.Anonymous)
         assert(admin === admin)

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,7 +1,7 @@
 object Version {
     val scala = "3.1.3"
 
-    val circe = "0.15.0-M1"
+    val circe = "0.14.2"
 
     val munit = "0.7.29"
 


### PR DESCRIPTION
closes #27

I changed circe version from `0.15.0-M1` to `0.14.2` as it's newer one. `0.15.0-M1` is heavily outdated one.