### PR TITLE
feat: introduce `circe-compat_213` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/target
+**/target*
 project/**/metals.sbt
 *.sc
 .bloop

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import sbt.librarymanagement.For3Use2_13
+
 name           := "derivation"
 publish / skip := true
 
@@ -95,6 +97,17 @@ lazy val circe = project
     .settings(
       name                              := "derivation-circe",
       libraryDependencies += "io.circe" %% "circe-core" % Version.circe,
+      defaultSettings,
+    )
+    .dependsOn(derivation)
+
+// circe codecs which for compatibility uses circe-core_2.13 artifact
+lazy val `circe-compat_213` = project
+    .in(modules / "circe")
+    .settings(
+      name                              := "derivation-circe-compat213",
+      target                            := (file("modules") / "circe" / "target-compat213" / "jvm").getAbsoluteFile,
+      libraryDependencies += "io.circe" %% "circe-core" % Version.circe cross For3Use2_13(),
       defaultSettings,
     )
     .dependsOn(derivation)


### PR DESCRIPTION
That module is exactly the same as circe but it depends on circe-core 2.13 artifact

It may be useful for anyone, who for some reasons is forced to stick with 2.13 artifacts.

I'm open for better approaches.