### PR TITLE
'-deprecation' compiler flag; fix LowPriorityEquiv warning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ val scala3Settings = scalacOptions ++= Vector(
   "-encoding",
   "utf-8",
   "-Yshow-suppressed-errors",
+  "-deprecation",
 )
 
 val testDependencies = libraryDependencies ++= Vector(

--- a/modules/cats/src/main/scala/evo/derivation/cats/EvoEq.scala
+++ b/modules/cats/src/main/scala/evo/derivation/cats/EvoEq.scala
@@ -19,9 +19,9 @@ object BaseEvoEq:
             case byCats: cats.kernel.Eq[A] =>
                 new:
                     def eqv(a: A, b: A) = byCats.eqv(a, b)
-            case byScala: Equiv[A]         =>
+            case _                         =>
                 new:
-                    def eqv(a: A, b: A) = byScala.equiv(a, b)
+                    def eqv(a: A, b: A) = Equiv.universal[A].equiv(a, b)
         }
 end BaseEvoEq
 


### PR DESCRIPTION
There is a deprecation warning on using `Equiv` implicit, which was deprecated since 2.13.0
The warning spreads in cascade to the projects using the library, when `-deprecation` compiler flag is enabled

cc @Odomontois 