### PR TITLE
logstage derivation module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,3 +120,16 @@ lazy val playJson = project
       defaultSettings,
     )
     .dependsOn(derivation)
+
+lazy val logstage = project
+    .in(modules / "logstage")
+    .settings(
+      name := "derivation-logstage",
+      libraryDependencies ++= Seq(
+        "io.7mind.izumi" %% "logstage-core"            % Version.logstage,
+        "io.7mind.izumi" %% "logstage-rendering-circe" % Version.logstage % Test,
+        "io.circe"       %% "circe-parser"             % Version.circe    % Test,
+      ),
+      defaultSettings,
+    )
+    .dependsOn(derivation)

--- a/modules/core/src/main/scala/evo/derivation/LazySummon.scala
+++ b/modules/core/src/main/scala/evo/derivation/LazySummon.scala
@@ -92,6 +92,16 @@ object LazySummon:
                 }
                 .toVector
 
+        def useForeach[U, Info](fields: Fields, infos: Vector[Info])(
+            f: [A] => (Info, A, TC[A]) => U,
+        ): Unit =
+            fields.toArray
+                .lazyZip(all)
+                .lazyZip(infos)
+                .foreach[U] { (field, inst, info) =>
+                    f(info, field.asInstanceOf[inst.FieldType], inst.tc)
+                }
+
         def useEitherFast[Info, E](infos: IArray[Info])(
             f: (summon: Of[TC], info: Info) => Either[E, summon.FieldType],
         ): Either[E, Fields] =

--- a/modules/logstage/src/main/scala/evo/derivation/logstage/EvoLog.scala
+++ b/modules/logstage/src/main/scala/evo/derivation/logstage/EvoLog.scala
@@ -14,10 +14,13 @@ import scala.deriving.Mirror.SumOf
 // Unable to extend LogstageCodec here due to problems with derivations for contravariant type classes
 trait EvoLog[A]:
     def write(writer: LogstageWriter, value: A): Unit
+    def writeInner(writer: LogstageWriter, value: A): Unit
 
 object EvoLog extends EvoLogTemplate:
     def fromLogstage[A](using codec: => LogstageCodec[A]): EvoLog[A] =
-        (writer: LogstageWriter, value: A) => codec.write(writer, value)
+        new EvoLog[A]:
+            override def writeInner(writer: LogstageWriter, value: A): Unit = codec.write(writer, value)
+            override def write(writer: LogstageWriter, value: A): Unit      = codec.write(writer, value)
 
     given [A](using LogstageCodec[A]): EvoLog[A] = fromLogstage
 end EvoLog
@@ -28,21 +31,28 @@ trait EvoLogTemplate extends HomogenicTemplate[EvoLog], SummonHierarchy:
     )(using config: => Config[A], ev: A <:< Product): EvoLog[A] =
         lazy val infos = config.top.fields.map(_._2)
 
-        (writer, a) =>
-            val fields = tupleFromProduct(a)
+        new EvoLog[A]:
+            override def write(writer: LogstageWriter, value: A): Unit =
+                writer.openMap()
+                writeInner(writer, value)
+                writer.closeMap()
 
-            // TODO: support embed
-            writer.openMap()
-            all.useForeach[Unit, ForField[_]](fields, infos) {
-                [X] =>
-                    (info: ForField[_], a: X, codec: EvoLog[X]) =>
-                        writer.nextMapElementOpen()
-                        LogstageCodec[String].write(writer, info.name)
-                        writer.mapElementSplitter()
-                        codec.write(writer, a)
-                        writer.nextMapElementClose()
-            }
-            writer.closeMap()
+            override def writeInner(writer: LogstageWriter, value: A): Unit =
+                val fields = tupleFromProduct(value)
+
+                all.useForeach[Unit, ForField[_]](fields, infos) {
+                    [X] =>
+                        (info: ForField[_], a: X, codec: EvoLog[X]) =>
+                            if (info.embed) codec.writeInner(writer, a)
+                            else
+                                writer.nextMapElementOpen()
+                                LogstageCodec[String].write(writer, info.name)
+                                writer.mapElementSplitter()
+                                codec.write(writer, a)
+                                writer.nextMapElementClose()
+                }
+            end writeInner
+        end new
     end product
 
     override def sum[A](using mirror: SumOf[A])(
@@ -52,25 +62,41 @@ trait EvoLogTemplate extends HomogenicTemplate[EvoLog], SummonHierarchy:
         lazy val cfg                            = config
         lazy val codecs: Map[String, EvoLog[A]] = mkSubMap
 
-        (writer, a) =>
-            val constructor  = matching.matched(a)
-            val discrimValue = cfg.name(constructor)
+        new EvoLog[A]:
+            override def write(writer: LogstageWriter, value: A): Unit =
+                writer.openMap()
+                writeInner(writer, value)
+                writer.closeMap()
 
-            // TODO: support discriminator
-            codecs
-                .get(constructor)
-                .foreach( // throw exception if empty?
-                  codec =>
-                      writer.openMap()
-                      writer.nextMapElementOpen()
-                      LogstageCodec[String].write(writer, discrimValue)
-                      writer.mapElementSplitter()
-                      codec.write(writer, a)
-                      writer.nextMapElementClose()
-                      writer.closeMap(),
-                )
+            override def writeInner(writer: LogstageWriter, value: A): Unit =
+                val constructor  = matching.matched(value)
+                val discrimValue = cfg.name(constructor)
+
+                (codecs.get(constructor), config.discriminator) match
+                    case (Some(codec), Some(discr)) =>
+                        writer.nextMapElementOpen()
+                        LogstageCodec[String].write(writer, discr)
+                        writer.mapElementSplitter()
+                        LogstageCodec[String].write(writer, discrimValue)
+                        writer.nextMapElementClose()
+                        codec.writeInner(writer, value)
+                    case (Some(codec), None)        =>
+                        writer.nextMapElementOpen()
+                        LogstageCodec[String].write(writer, discrimValue)
+                        writer.mapElementSplitter()
+                        codec.write(writer, value)
+                        writer.nextMapElementClose()
+                    case (_, _)                     => () // throw exception
+                end match
+            end writeInner
+        end new
     end sum
 
     override def newtype[A](using nt: ValueClass[A])(using codec: EvoLog[nt.Representation]): EvoLog[A] =
-        (writer, a) => codec.write(writer, nt.to(a))
+        new EvoLog[A]:
+            override def write(writer: LogstageWriter, value: A): Unit =
+                codec.write(writer, nt.to(value))
+
+            override def writeInner(writer: LogstageWriter, value: A): Unit =
+                codec.write(writer, nt.to(value))
 end EvoLogTemplate

--- a/modules/logstage/src/main/scala/evo/derivation/logstage/EvoLog.scala
+++ b/modules/logstage/src/main/scala/evo/derivation/logstage/EvoLog.scala
@@ -1,0 +1,73 @@
+package evo.derivation.logstage
+
+import evo.derivation.LazySummon.All
+import evo.derivation.{LazySummon, ValueClass}
+import evo.derivation.config.{Config, ForField}
+import evo.derivation.internal.{Matching, tupleFromProduct}
+import evo.derivation.template.{ConsistentTemplate, HomogenicTemplate, SummonHierarchy, Template}
+import izumi.logstage.api.rendering.{LogstageCodec, LogstageWriter}
+import logstage.LogstageCodec
+
+import scala.deriving.Mirror
+import scala.deriving.Mirror.SumOf
+
+// Unable to extend LogstageCodec here due to problems with derivations for contravariant type classes
+trait EvoLog[A]:
+    def write(writer: LogstageWriter, value: A): Unit
+
+object EvoLog extends EvoLogTemplate:
+    def fromLogstage[A](using codec: => LogstageCodec[A]): EvoLog[A] =
+        (writer: LogstageWriter, value: A) => codec.write(writer, value)
+
+    given [A](using LogstageCodec[A]): EvoLog[A] = fromLogstage
+end EvoLog
+
+trait EvoLogTemplate extends HomogenicTemplate[EvoLog], SummonHierarchy:
+    override def product[A](using mirror: Mirror.ProductOf[A])(
+        all: LazySummon.All[OfField, mirror.MirroredElemTypes],
+    )(using config: => Config[A], ev: A <:< Product): EvoLog[A] =
+        lazy val infos = config.top.fields.map(_._2)
+
+        (writer, a) =>
+            val fields = tupleFromProduct(a)
+
+            writer.openMap()
+            all.useForeach[Unit, ForField[_]](fields, infos) {
+                [X] =>
+                    (info: ForField[_], a: X, codec: EvoLog[X]) =>
+                        writer.nextMapElementOpen()
+                        LogstageCodec[String].write(writer, info.name)
+                        writer.mapElementSplitter()
+                        codec.write(writer, a)
+                        writer.nextMapElementClose()
+            }
+            writer.closeMap()
+    end product
+
+    override def sum[A](using mirror: SumOf[A])(
+        subs: All[EvoLog, mirror.MirroredElemTypes],
+        mkSubMap: => Map[String, EvoLog[A]],
+    )(using config: => Config[A], matching: Matching[A]): EvoLog[A] =
+        lazy val cfg                            = config
+        lazy val codecs: Map[String, EvoLog[A]] = mkSubMap
+
+        (writer, a) =>
+            val constructor  = matching.matched(a)
+            val discrimValue = cfg.name(constructor)
+
+            (codecs.get(constructor), cfg.discriminator) match
+                case (Some(codec), _) =>    // TODO: support discriminator
+                    writer.openMap()
+                    writer.nextMapElementOpen()
+                    LogstageCodec[String].write(writer, discrimValue)
+                    writer.mapElementSplitter()
+                    codec.write(writer, a)
+                    writer.nextMapElementClose()
+                    writer.closeMap()
+                case (None, _)        => () // throw exception ?
+            end match
+    end sum
+
+    override def newtype[A](using nt: ValueClass[A])(using codec: EvoLog[nt.Representation]): EvoLog[A] =
+        (writer, a) => codec.write(writer, nt.to(a))
+end EvoLogTemplate

--- a/modules/logstage/src/main/scala/evo/derivation/logstage/Masked.scala
+++ b/modules/logstage/src/main/scala/evo/derivation/logstage/Masked.scala
@@ -1,0 +1,5 @@
+package evo.derivation.logstage
+
+import evo.derivation.Custom
+
+case class Masked(template: String = "***masked***") extends Custom

--- a/modules/logstage/src/main/scala/evo/derivation/logstage/instances.scala
+++ b/modules/logstage/src/main/scala/evo/derivation/logstage/instances.scala
@@ -1,0 +1,9 @@
+package evo.derivation.logstage
+
+import izumi.logstage.api.rendering.{LogstageCodec, LogstageWriter}
+
+trait EvoLogInstances:
+    given [A](using e: EvoLog[A]): LogstageCodec[A] =
+        (writer: LogstageWriter, value: A) => e.write(writer, value)
+
+object instances extends EvoLogInstances

--- a/modules/logstage/src/test/scala/evo/derivation/logstage/LogstageTest.scala
+++ b/modules/logstage/src/test/scala/evo/derivation/logstage/LogstageTest.scala
@@ -51,12 +51,9 @@ class LogstageTest extends munit.FunSuite:
         val case1 =
             """
             |{
-            |  "variant" : {
-            |    "Case1" : {
-            |      "foo" : 1,
-            |      "param" : "cheb"
-            |    }
-            |  },
+            |  "type" : "Case1",
+            |  "foo" : 1,
+            |  "param" : "cheb",
             |  "props" : {
             |    "lol" : "kek",
             |    "sad" : "pet"
@@ -72,11 +69,8 @@ class LogstageTest extends munit.FunSuite:
         val case2 =
             """
             |{
-            |  "variant" : {
-            |    "Case2" : {
-            |      "foo" : 10
-            |    }
-            |  },
+            |  "type" : "Case2",
+            |  "foo": 10,
             |  "props" : {}
             |}
             |""".stripMargin
@@ -96,10 +90,11 @@ object EvoLogTest:
         case No
         case Bazz(i: Int)
 
+    @Discriminator("type")
     enum OneOf derives Config, EvoLog:
         case Case1(foo: Int, param: String)
         case Case2(foo: Int)
         case Case3(param: String)
 
-    case class WithProps(variant: OneOf, props: Map[String, String]) derives Config, EvoLog
+    case class WithProps(@Embed variant: OneOf, props: Map[String, String]) derives Config, EvoLog
 end EvoLogTest

--- a/modules/logstage/src/test/scala/evo/derivation/logstage/LogstageTest.scala
+++ b/modules/logstage/src/test/scala/evo/derivation/logstage/LogstageTest.scala
@@ -1,0 +1,105 @@
+package evo.derivation.logstage
+
+import evo.derivation.config.Config
+import io.circe.Json
+import logstage.LogstageCodec
+import izumi.logstage.api.rendering.json.LogstageCirceWriter
+import EvoLogTest.{WithProps, OneOf, SimpleRec}
+import evo.derivation.{Discriminator, Embed, Rename, SnakeCase}
+import izumi.logstage.api.rendering.{LogstageCodec, LogstageWriter}
+import io.circe.parser.parse
+
+class LogstageTest extends munit.FunSuite:
+    import evo.derivation.logstage.instances.given // arggh
+
+    extension [A](a: A)
+        def toLog(using codec: LogstageCodec[A]): Json =
+            LogstageCirceWriter.write(codec, a)
+
+    test("simple recursive data") {
+        val chebKekLol =
+            """
+            |{
+            |  "bazar" : {
+            |    "foo" : {
+            |      "bazar" : {
+            |        "foo" : {
+            |          "bazar" : {
+            |            "foo" : {
+            |              "no" : {}
+            |            },
+            |            "param" : "cheb"
+            |          }
+            |        },
+            |        "param" : "kek"
+            |      }
+            |    },
+            |    "param" : "lol"
+            |  }
+            |}
+            |""".stripMargin
+
+        assertEquals(
+          parse(chebKekLol),
+          Right(
+            (SimpleRec.Bar(SimpleRec.Bar(SimpleRec.Bar(SimpleRec.No, "cheb"), "kek"), "lol"): SimpleRec).toLog,
+          ),
+        )
+    }
+
+    test("WithProps") {
+        val case1 =
+            """
+            |{
+            |  "variant" : {
+            |    "Case1" : {
+            |      "foo" : 1,
+            |      "param" : "cheb"
+            |    }
+            |  },
+            |  "props" : {
+            |    "lol" : "kek",
+            |    "sad" : "pet"
+            |  }
+            |}
+            |""".stripMargin
+
+        assertEquals(
+          parse(case1),
+          Right(WithProps(OneOf.Case1(1, "cheb"), Map("lol" -> "kek", "sad" -> "pet")).toLog),
+        )
+
+        val case2 =
+            """
+            |{
+            |  "variant" : {
+            |    "Case2" : {
+            |      "foo" : 10
+            |    }
+            |  },
+            |  "props" : {}
+            |}
+            |""".stripMargin
+
+        assertEquals(
+          parse(case2),
+          Right(WithProps(OneOf.Case2(10), Map()).toLog),
+        )
+    }
+
+end LogstageTest
+
+object EvoLogTest:
+    @SnakeCase
+    enum SimpleRec derives Config, EvoLog:
+        @Rename("bazar") case Bar(foo: SimpleRec, param: String)
+        case No
+        case Bazz(i: Int)
+
+    enum OneOf derives Config, EvoLog:
+        case Case1(foo: Int, param: String)
+        case Case2(foo: Int)
+        case Case3(param: String)
+
+    case class WithProps(variant: OneOf, props: Map[String, String]) derives Config, EvoLog
+end EvoLogTest

--- a/modules/logstage/src/test/scala/evo/derivation/logstage/LogstageTest.scala
+++ b/modules/logstage/src/test/scala/evo/derivation/logstage/LogstageTest.scala
@@ -71,7 +71,7 @@ class LogstageTest extends munit.FunSuite:
             """
             |{
             |  "type" : "Case2",
-            |  "foo": 10,
+            |  "foo": "***masked***",
             |  "props" : {}
             |}
             |""".stripMargin
@@ -120,9 +120,7 @@ class LogstageTest extends munit.FunSuite:
               |  "variant" : {
               |    "foo" : 100
               |  },
-              |  "props" : {
-              |    "lol" : "zoo"
-              |  }
+              |  "props" : "***masked***"
               |}
               |""".stripMargin
 
@@ -145,7 +143,7 @@ object EvoLogTest:
     @Discriminator("type")
     enum OneOf derives Config, EvoLog:
         case Case1(foo: Int, param: String)
-        case Case2(foo: Int)
+        case Case2(@Masked foo: Int)
         case Case3(param: String)
 
     case class WithProps(@Embed variant: OneOf, props: Map[String, String]) derives Config, EvoLog
@@ -166,5 +164,5 @@ object EvoLogTest:
     end OneOfCustom
 
     // Embed is ignored in this case
-    case class Custom(@Embed variant: OneOfCustom, props: Map[String, String]) derives Config, EvoLog
+    case class Custom(@Embed variant: OneOfCustom, @Masked props: Map[String, String]) derives Config, EvoLog
 end EvoLogTest

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -10,4 +10,6 @@ object Version {
     val playJson = "2.9.3"
 
     val cats = "2.9.0"
+
+    val logstage = "1.1.0-M23"
 }


### PR DESCRIPTION
This pull request provides basic support for derivation `LogstageCodec` from `izumi.logstage` library.

Quick example:
```scala
@SnakeCase
@Discriminator("type")
enum User derives Config, EvoLog:
  case AuthorizedClient(@Rename("client_id") id: Long, name: String, @Masked token: String)
  case Anonymous

import logstage.IzLogger
val logger = IzLogger()
val user = User.AuthorizedClient(100, "Bob", "123")

import evo.derivation.logstage.instances.given // arggh
logger.trace(s"User: $user")
```
Will print:
```
T 2023-06-08T18:45:34.795 (LogstageTest.scala:27)  …ation.logstage.LogstageTest [1:main] User: user={type: authorized_client; client_id: 100; name: Bob; token: ***masked***}
```

The problem is that `LogstageCodec` is contravariant, so `EvoLog` doesn't extend `LogstageCodec`, and that's why `import evo.derivation.logstage.instances.given` here.